### PR TITLE
Update DebugRouterCommand.php

### DIFF
--- a/Command/DebugRouterCommand.php
+++ b/Command/DebugRouterCommand.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
 
 class DebugRouterCommand extends Command
 {
@@ -50,7 +52,14 @@ class DebugRouterCommand extends Command
         $router = $this->routers[$rname];
 
         $collection = $router->getCollection();
-        $table = new Table($output);
+        
+        $version = Kernel::VERSION_ID;
+        if ($version < 30000) {
+            $table = $this->getHelperSet()->get('table');
+        } else {
+            $table = new Table($output);
+        }
+        
         $table->setHeaders(['Name', 'Pattern', 'Callback']);
 
         $rows = [];

--- a/Command/DebugRouterCommand.php
+++ b/Command/DebugRouterCommand.php
@@ -4,6 +4,7 @@ namespace Gos\Bundle\PubSubRouterBundle\Command;
 
 use Gos\Bundle\PubSubRouterBundle\Router\RouterInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/Command/DebugRouterCommand.php
+++ b/Command/DebugRouterCommand.php
@@ -49,7 +49,7 @@ class DebugRouterCommand extends Command
         $router = $this->routers[$rname];
 
         $collection = $router->getCollection();
-        $table = $this->getHelperSet()->get('table');
+        $table = new Table($output);
         $table->setHeaders(['Name', 'Pattern', 'Callback']);
 
         $rows = [];


### PR DESCRIPTION
The Table Helper was deprecated in Symfony 2.5 and removed in Symfony 3.0. You should now use the Table class instead which is more powerful. http://symfony.com/doc/current/components/console/helpers/tablehelper.html