### PR TITLE
Bump minimum support to Symfony 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: php
 php:
     - 5.5
     - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
     - hhvm-nightly
 
 matrix:

--- a/Cache/CacheWarmer.php
+++ b/Cache/CacheWarmer.php
@@ -5,7 +5,6 @@ namespace Gos\Bundle\PubSubRouterBundle\Cache;
 use Doctrine\Common\Cache\Cache;
 use Gos\Bundle\PubSubRouterBundle\Loader\RouteLoader;
 use Gos\Bundle\PubSubRouterBundle\Router\RouteCollection;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
@@ -45,14 +44,13 @@ class CacheWarmer implements CacheWarmerInterface
         $registeredRouter = $this->container->getParameter('gos_pubsub_registered_routers');
 
         foreach ($registeredRouter as $routerType) {
-
             /** @var RouteCollection $collection */
             $collection = $this->container->get('gos_pubsub_router.collection.' . $routerType);
 
             /** @var RouteLoader $loader */
             $loader = $this->container->get('gos_pubsub_router.loader.' . $routerType);
 
-            $loader->load($collection); //trigger cache on route collection
+            $loader->load(); //trigger cache on route collection
         }
     }
 }

--- a/Cache/PhpFileCacheDecorator.php
+++ b/Cache/PhpFileCacheDecorator.php
@@ -3,10 +3,11 @@
 namespace Gos\Bundle\PubSubRouterBundle\Cache;
 
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\PhpFileCache;
 
 class PhpFileCacheDecorator implements Cache
 {
-    /** @var \Doctrine\Common\Cache\PhpFileCache */
+    /** @var PhpFileCache */
     protected $cache;
 
     /** @var  bool */
@@ -19,7 +20,7 @@ class PhpFileCacheDecorator implements Cache
     public function __construct($cacheDir, $debug)
     {
         $this->debug = $debug;
-        $this->cache = new \Doctrine\Common\Cache\PhpFileCache($cacheDir, '.pubSubRouter.php');
+        $this->cache = new PhpFileCache($cacheDir, '.pubSubRouter.php');
         $this->cache->setNamespace('pubsub_router');
     }
 

--- a/Generator/Generator.php
+++ b/Generator/Generator.php
@@ -47,7 +47,7 @@ class Generator implements GeneratorInterface
 
         if (false === $route) {
             throw new ResourceNotFoundException(sprintf(
-                'Route %s not exists in [%s]',
+                'Route %s does not exist in [%s]',
                 $routeName,
                 implode(', ', array_keys($this->collection->all()))
             ));

--- a/Router/Route.php
+++ b/Router/Route.php
@@ -38,7 +38,7 @@ class Route implements RouteInterface
      * @param array           $args
      * @param array           $requirements
      */
-    public function __construct($pattern, $callback, Array $args = [], Array $requirements = [])
+    public function __construct($pattern, $callback, array $args = [], array $requirements = [])
     {
         $this->pattern = $pattern;
         $this->callback = $callback;

--- a/Router/RouteCollection.php
+++ b/Router/RouteCollection.php
@@ -25,7 +25,7 @@ class RouteCollection implements \Countable, \IteratorAggregate
     /**
      * @param RouteInterface[] $routes
      */
-    public function __construct(Array $routes = null)
+    public function __construct(array $routes = null)
     {
         if (null !== $routes) {
             foreach ($routes as $routeName => $route) {
@@ -38,9 +38,9 @@ class RouteCollection implements \Countable, \IteratorAggregate
 
     public function __clone()
     {
-        /*
-         * @var string
-         * @var RouteInterface
+        /**
+         * @var string $name
+         * @var RouteInterface $route
          */
         foreach ($this->routes as $name => $route) {
             $this->routes[$name] = clone $route;

--- a/Router/RouteInterface.php
+++ b/Router/RouteInterface.php
@@ -10,7 +10,7 @@ interface RouteInterface
     public function getPattern();
 
     /**
-     * @return Callable|string
+     * @return callable|string
      */
     public function getCallback();
 

--- a/Router/Router.php
+++ b/Router/Router.php
@@ -89,7 +89,7 @@ class Router implements RouterInterface
     /**
      * {@inheritdoc}
      */
-    public function generate($routeName, Array $parameters = [], $tokenSeparator = null)
+    public function generate($routeName, array $parameters = [], $tokenSeparator = null)
     {
         $this->generator->setCollection($this->collection);
 
@@ -103,7 +103,7 @@ class Router implements RouterInterface
     /**
      * {@inheritdoc}
      */
-    public function generateFromTokens(RouteInterface $route, Array $tokens, Array $parameters = [], $tokenSeparator = null)
+    public function generateFromTokens(RouteInterface $route, array $tokens, array $parameters = [], $tokenSeparator = null)
     {
         if (null === $tokenSeparator && null !== $this->context) {
             $tokenSeparator = $this->context->getTokenSeparator();

--- a/Router/RouterContext.php
+++ b/Router/RouterContext.php
@@ -23,7 +23,7 @@ class RouterContext
     /**
      * @param string $tokenSeparator
      *
-     * @return $this|RouterContext
+     * @return $this
      */
     public function setTokenSeparator($tokenSeparator)
     {

--- a/Tokenizer/Token.php
+++ b/Tokenizer/Token.php
@@ -15,7 +15,7 @@ class Token
     protected $expression;
 
     /**
-     * @var Array
+     * @var array
      */
     protected $requirements;
 
@@ -76,13 +76,13 @@ class Token
     /**
      * @param array $requirements
      */
-    public function setRequirements(Array $requirements)
+    public function setRequirements(array $requirements)
     {
         $this->requirements = $requirements;
     }
 
     /**
-     * @return Array
+     * @return array
      */
     public function getRequirements()
     {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
     ],
     "require": {
         "php": ">=5.5",
-        "symfony/framework-bundle": "~3.4|~4.0",
-        "doctrine/cache": "~1.4"
+        "doctrine/cache": "~1.4",
+        "symfony/console": "~3.4|~4.0",
+        "symfony/framework-bundle": "~3.4|~4.0"
     },
     "require-dev":{
         "phpunit/phpunit": "^4.8.35"

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
+        "php": ">=5.5",
+        "symfony/framework-bundle": "~3.4|~4.0",
         "doctrine/cache": "~1.4"
     },
     "require-dev":{
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
         "psr-4": { "Gos\\Bundle\\PubSubRouterBundle\\": "" }
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2.x-dev"
+            "dev-master": "0.3.x-dev"
         }
     }
 }


### PR DESCRIPTION
Rather conservatively...

- Drops Symfony 2.x support, require the current LTS (3.4) or 4.x
- Drops PHP 5.4 support as Symfony 3.x requires 5.5.9 anyway
- Cleans up Symfony 2.x support in the console command and makes it lazy
- Other miscellaneous code cleanup